### PR TITLE
Cascade oversight board consensus

### DIFF
--- a/Ideas-2019.md
+++ b/Ideas-2019.md
@@ -16,18 +16,24 @@ student or a mentor to suggest ideas.
    student is not selected; these are shown as a _coding mentor_,
 
 ## Coding Mentors
-We must have one or more _coding mentors_ willing and able to assist
-students with coding questions.
+For each idea, we must have offers from one or more _coding mentors_
+willing and able to assist students with coding questions.
 
 Requirements for a _coding mentor_ are a demonstrated coding ability
 in the form of contributions of code to Sugar Labs.
 
-## Assisting Mentors
-We also have some mentors _who do not code_ willing to assist students
-in various other ways, such as gathering requirements, visual design,
-testing, and deployment; these are shown as an _assisting mentor_.
+Mentors for a project will be assigned after proposals are received.
 
-The only requirement for an _assisting mentor_ is _knowledge of the project_.
+## Assisting Mentors
+For each idea, we may have offers from mentors _who do not code_
+willing to assist students in various other ways, such as gathering
+requirements, visual design, testing, and deployment; these are shown
+as an _assisting mentor_.
+
+The only requirement for an _assisting mentor_ is _knowledge of the
+project_.
+
+Mentors for a project will be assigned after proposals are received.
 
 ## Suggested Issues
 

--- a/Ideas-2019.md
+++ b/Ideas-2019.md
@@ -43,7 +43,7 @@ _mentor_ is obliged to respond when a student has a question, even if
 the answer is "I don't know."
 
 When a _mentor_ receives a question for which the best forum is
-_everyone else_, then they are to repectively redirect the student to
+_everyone else_, then they are to respectively redirect the student to
 ask _everyone else_.  See
 [Be flexible](https://github.com/sugarlabs/sugar-docs/blob/master/src/CODE_OF_CONDUCT.md#be-flexible)
 and

--- a/Ideas-2019.md
+++ b/Ideas-2019.md
@@ -35,6 +35,21 @@ project_.
 
 Mentors for a project will be assigned after proposals are received.
 
+## Everyone Else
+Everyone else in Sugar Labs may also be involved with these projects, through mailing lists, Wiki, and GitHub.
+
+The difference between a _mentor_ and _everyone else_, is that a
+_mentor_ is obliged to respond when a student has a question, even if
+the answer is "I don't know."
+
+When a _mentor_ receives a question for which the best forum is
+_everyone else_, then they are to repectively redirect the student to
+ask _everyone else_.  See
+[Be flexible](https://github.com/sugarlabs/sugar-docs/blob/master/src/CODE_OF_CONDUCT.md#be-flexible)
+and
+[When you are unsure, ask for help](https://github.com/sugarlabs/sugar-docs/blob/master/src/CODE_OF_CONDUCT.md#when-you-are-unsure-ask-for-help)
+in our Code of Conduct.
+
 ## Suggested Issues
 
 For some ideas, there is a list of 'Suggested issues to work on'.


### PR DESCRIPTION
* we will hold off inviting mentors until proposals arrive; so that we
  know what sort of proposals we are getting

* the hold off will also help make sure that participants do not design
  their proposals to meet requirements of mentors,

* we may designative a main mentor on each idea, to help with approval
  of proposals,

https://wiki.sugarlabs.org/go/Oversight_Board/Meeting_Minutes-2019-03-01#Receive_Report_from_Google_Summer_of_Code_Sugar_Labs_organisation_administrator

http://meeting.sugarlabs.org/sugar-meeting/meetings/2019-03-01T18:58:42#i_2954176