### PR TITLE
Remove IRC as a recommended medium for contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Shortcuts
 
-|[GSoC'19 Ideas](Ideas-2019.md)| [Proposal Template](Template.md) | [Sugar Labs @GitHub](https://github.com/sugarlabs) | [Sugar Labs @IRC](https://webchat.freenode.net) |
-|:-------------------------:|----------------------|----------------------|--------------------------|
-|<a href="Ideas-2019.md">![](assets/gsoc-square.png)</a> | <a href="Template.md">![](assets/template.png)</a> | <a href="https://github.com/sugarlabs">![](assets/github.png)</a> |<a href="https://webchat.freenode.net">![](assets/sugar-labs.png)</a> |
+|[GSoC'19 Ideas](Ideas-2019.md)| [Proposal Template](Template.md) | [Sugar Labs @GitHub](https://github.com/sugarlabs) |
+|:-------------------------:|----------------------|----------------------|
+|<a href="Ideas-2019.md">![](assets/gsoc-square.png)</a> | <a href="Template.md">![](assets/template.png)</a> | <a href="https://github.com/sugarlabs">![](assets/github.png)</a> |
 
 
 ## Introduction
@@ -44,13 +44,12 @@ Before you start writing your proposal, go through our [Proposal
 Template](Template.md).
 
 ## How to talk to us ?
-We use `#sugar` and `#sugar-meeting` channels on
-[IRC](https://webchat.freenode.net) and 
+We use the
 [sugar-devel@](http://lists.sugarlabs.org/listinfo/sugar-devel)
-mailing list for communication. You can join our IRC channels
-and mailing list to participate in the discussions and asking
-for help. **Do not contact individual mentors / developers
-privately, asking for help.** See
+mailing list for communication. You can join
+the mailing list to participate in the discussions and ask
+for help.  Please do not contact individual mentors / developers
+privately, asking for help.  See
 [Community etiquette](https://github.com/sugarlabs/GSoC#community-etiquette)
 
 ## How to Contribute

--- a/Template.md
+++ b/Template.md
@@ -14,7 +14,6 @@ Finish writing your proposal early so that you can get it reviewed by your mento
 ## Basic Details
  - Full Name
  - Email and GitHub Username
- - IRC nickname on #sugar
  - Your first language
  - Location and Timezone
  - Share links, if any, of your previous work on open source projects ?<br>


### PR DESCRIPTION
Both IRC and Gitter are not working well enough for us to handle
arriving prospects;

(a) because the mentors, developers, and reviewers are not present,

(b) it deceives students into trusting random people who have given
incorrect or incomplete advice,

The better forum is our mailing list.

This doesn't stop us from using IRC or Gitter during GSoC, of course.