### PR TITLE
Fix typo and incorrect markdown

### DIFF
--- a/Ideas-2023.md
+++ b/Ideas-2023.md
@@ -169,8 +169,7 @@ To be added.
 **Prerequisites**<br>
  - Experience with Python
  - Strong experience with
-   [Sugar Desktop](https://github.com/sugarlabs/sugar) and activities
-Activities](https://github.com/sugarlabs/sugar-docs/blob/master/src/contributing.md#modifying-activities)
+   [Sugar Desktop](https://github.com/sugarlabs/sugar) and [Activities](https://github.com/sugarlabs/sugar-docs/blob/master/src/contributing.md#modifying-activities)
 
 **Description**<br>We have a number of Sugar Activities bundled with
   [Flatpak](https://flatpak.org/) as a way to reach a broader audience


### PR DESCRIPTION
Fixed a typo and corrected a incorrect markdown #179 
before:
![image](https://user-images.githubusercontent.com/21291203/224486637-8c82e0c4-11fe-48cb-9fc3-e2d0b1f26d1d.png)
after:
![image](https://user-images.githubusercontent.com/21291203/224486664-c3311615-404c-4113-bd92-d2489e39fb9a.png)
