### PR TITLE
Add idea for a sample/synth improvement project for Music Blocks

### DIFF
--- a/Ideas-2025.md
+++ b/Ideas-2025.md
@@ -37,6 +37,37 @@ The chatbot could provide real-time assistance—answering questions, explaining
 
 ------------
 
+## Improved tone/timbre features
+
+**Prerequisites**<br>
+ - Experience with JavaScript
+ - Experience with Music Blocks
+ - Experience with Tone.JS
+ - Experience with LLMs/neural-networks
+
+**Description**<br>
+Users have two main methods within Music Blocks to play with sound: synths and samples. For our synth, we use tone.js. For samples, we use a .wav binaries and transpose the sound to different pitches. While these features work "well enough", there is still more that can been to make them useful. For this project, a contributor would work closely with their mentors to 1) update the sampler widget, 2) port a list of free/libre/open samples into Music Blocks, and 3) create an API to a gen-AI to generate samples based on a user prompt.
+
+Updating the sampler widget will involve updating tone.js to its current version, debugging any issues that updates may cause, and making improvements to the UI/UX of the widget itself.
+
+Porting samples into Music Blocks will require following the directions specified in the Music Blocks documentation to convert a curated list of samples. After completing this, the user-facing menus showing the samples will need to be updated and organized based on instrument type. There is some room to get creative with the presentation of the instruments, perhaps adding icons for each instrument.
+
+The final part of this project requires a little bit of gen-AI experience. In order to give users (nearly) limitless options for samples, we are adding to the project's scope a gen-AI-enabled sample generator. A user should be able to prompt a sound font, such as "heavy metal guitar with deep bass" or "soothing clarinet with a crisp attack" and get a result that they can use in their project's code. A contributor will need to extend our sample widget (which currently records audio) to accept a user prompt, create an API to call an LLM/neural-network backend, and test/tweak the gen-AI backend to create an appropriate sample for the user. The results of this part of the project need not be "perfect" by the end of the summer. A solid proof of concept will be sufficient.
+
+**Project Length**<br>
+
+**350** hours
+
+**Difficulty**<br>
+
+**Hard**<br>
+
+**Coding Mentors**<br>
+[Walter Bender](https://github.com/walterbender/)<br>
+**Assisting Mentors**<br>
+[Devin Ulibarri](https://github.com/pikurasa/)
+
+------------
 
 ## Code generation for lesson plans and model abstraction layer
 

--- a/Ideas-2025.md
+++ b/Ideas-2025.md
@@ -37,7 +37,38 @@ The chatbot could provide real-time assistance—answering questions, explaining
 
 ------------
 
-## Improved tone/timbre features
+## Improve syth and sample features in Music Blocks
+
+**Prerequisites**<br>
+ - Experience with JavaScript
+ - Experience with Music Blocks
+ - Experience with Tone.JS
+
+**Description**<br>
+Users have two main methods within Music Blocks to play with sound: synths and samples. For our synth, we use tone.js. For samples, we use a .wav binaries and transpose the sound to different pitches. While these features work "well enough", there is still more that can been to make them useful. For this project, a contributor would work closely with their mentors to 1) update the sampler widget, 2) port a list of free/libre/open samples into Music Blocks, and 3) add to the *Set Instrument* feature and *Sampler Widget* the ability to assign multiple samples for the same instrument with criteria (e.g. high and low, short and long) for a more natural sound.
+
+Updating the sampler widget will involve updating tone.js to its current version, debugging any issues that updates may cause, and making improvements to the UI/UX of the widget itself.
+
+Porting samples into Music Blocks will require following the directions specified in the Music Blocks documentation to convert a curated list of samples. After completing this, the user-facing menus showing the samples will need to be updated and organized based on instrument type. There is some room to get creative with the presentation of the instruments, perhaps adding icons for each instrument.
+
+The final part of the project is perhaps the most challenging. It will require adding additional functionality so that a user can either upload or record multiple samples of an instrument or voice to be assigned to a custom instrument in Music Blocks. Doing this will make the overall tone of the instruments more persuasive. For example, if the Music Blocks project has short, staccato sounds, the playback can use the short sample created by a recorded instrument.
+
+**Project Length**<br>
+
+**350** hours
+
+**Difficulty**<br>
+
+**Hard**<br>
+
+**Coding Mentors**<br>
+[Walter Bender](https://github.com/walterbender/)<br>
+**Assisting Mentors**<br>
+[Devin Ulibarri](https://github.com/pikurasa/)
+
+------------
+
+## Gen-AI instrument sample generation
 
 **Prerequisites**<br>
  - Experience with JavaScript
@@ -46,13 +77,9 @@ The chatbot could provide real-time assistance—answering questions, explaining
  - Experience with LLMs/neural-networks
 
 **Description**<br>
-Users have two main methods within Music Blocks to play with sound: synths and samples. For our synth, we use tone.js. For samples, we use a .wav binaries and transpose the sound to different pitches. While these features work "well enough", there is still more that can been to make them useful. For this project, a contributor would work closely with their mentors to 1) update the sampler widget, 2) port a list of free/libre/open samples into Music Blocks, and 3) create an API to a gen-AI to generate samples based on a user prompt.
+For this project, a contributor would work closely with their mentors create an API to a gen-AI to generate samples based on a user prompt.
 
-Updating the sampler widget will involve updating tone.js to its current version, debugging any issues that updates may cause, and making improvements to the UI/UX of the widget itself.
-
-Porting samples into Music Blocks will require following the directions specified in the Music Blocks documentation to convert a curated list of samples. After completing this, the user-facing menus showing the samples will need to be updated and organized based on instrument type. There is some room to get creative with the presentation of the instruments, perhaps adding icons for each instrument.
-
-The final part of this project requires a little bit of gen-AI experience. In order to give users (nearly) limitless options for samples, we are adding to the project's scope a gen-AI-enabled sample generator. A user should be able to prompt a sound font, such as "heavy metal guitar with deep bass" or "soothing clarinet with a crisp attack" and get a result that they can use in their project's code. A contributor will need to extend our sample widget (which currently records audio) to accept a user prompt, create an API to call an LLM/neural-network backend, and test/tweak the gen-AI backend to create an appropriate sample for the user. The results of this part of the project need not be "perfect" by the end of the summer. A solid proof of concept will be sufficient.
+In order to give users (nearly) limitless options for samples, we are adding to the project's scope a gen-AI-enabled sample generator. A user should be able to prompt a sound font, such as "heavy metal guitar with deep bass" or "soothing clarinet with a crisp attack" and get a result that they can use in their project's code. A contributor will need to extend our sample widget (which currently records audio) to accept a user prompt, create an API to call an LLM/neural-network backend, and test/tweak the gen-AI backend to create an appropriate sample for the user. The results of this part of the project need not be "perfect" by the end of the summer. A solid proof of concept will be sufficient.
 
 **Project Length**<br>
 


### PR DESCRIPTION
It would be nice to spend some time this summer improving timbre for Music Blocks. MB has synth and sample features.

For synth, we could use a reexamination of how we're using tone.js, including within our Timbre Widget.

For samples, the easiest thing we can do is port samples into MB from SonicPi (selections from https://github.com/sonic-pi-net/sonic-pi/tree/dev/etc/samples) and from places like this: https://sound-effects.bbcrewind.co.uk/ (shared by Walter). We just need to make sure that the license is compatible with ours (free/libre/open), and that it is of a certain quality.

I added the gen-AI thing for a few reasons. I do think it would be helpful for students, and I think they'd have a good time with it. But if that seems out of scope for this proposal, please let me know.