### PR TITLE
ci: validate markdown links for changed files in PRs

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,0 +1,13 @@
+exclude = [
+  '^http://lists\.sugarlabs\.org/listinfo/sugar-devel$',
+  '^https://wiki\.sugarlabs\.org/go/.*$',
+  '^https://www\.sugarlabs\.org/news/all/2025-09-01-gsoc-25-diwangshu-final-report$',
+  '^https://www\.sugarlabs\.org/news/all/2026-1-11-how-to-gtk4$',
+]
+
+max_retries = 2
+retry_wait_time = 2
+timeout = 20
+
+# Some sites throttle bot-like traffic.
+accept = [200, 403, 429]

--- a/.github/scripts/collect-markdown-files.sh
+++ b/.github/scripts/collect-markdown-files.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+    echo "GITHUB_OUTPUT is not set" >&2
+    exit 1
+fi
+
+declare -a markdown_files=()
+
+if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+    base_ref="${GITHUB_BASE_REF:-}"
+    if [[ -z "${base_ref}" ]]; then
+        echo "GITHUB_BASE_REF is not set for pull_request event" >&2
+        exit 1
+    fi
+
+    git fetch --no-tags --depth=1 origin "${base_ref}"
+
+    while IFS= read -r file; do
+        [[ -n "${file}" ]] && markdown_files+=("${file}")
+    done < <(git diff --name-only --diff-filter=ACMRT \
+        "origin/${base_ref}...${GITHUB_SHA}" -- '*.md')
+else
+    while IFS= read -r file; do
+        [[ -n "${file}" ]] && markdown_files+=("${file}")
+    done < <(git ls-files '*.md')
+fi
+
+if [[ "${#markdown_files[@]}" -eq 0 ]]; then
+    echo "has_files=false" >> "${GITHUB_OUTPUT}"
+    echo "No markdown files found for validation."
+    exit 0
+fi
+
+echo "has_files=true" >> "${GITHUB_OUTPUT}"
+
+{
+    echo "files<<EOF"
+    printf "%s\n" "${markdown_files[@]}"
+    echo "EOF"
+} >> "${GITHUB_OUTPUT}"
+
+echo "Markdown files selected for validation:"
+printf '%s\n' "${markdown_files[@]}"

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,39 @@
+name: Markdown Link Check
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "**/*.md"
+      - ".github/workflows/markdown-link-check.yml"
+      - ".github/scripts/collect-markdown-files.sh"
+      - ".github/lychee.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  check-links:
+    name: Validate markdown links
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect markdown files to validate
+        id: markdown
+        run: bash .github/scripts/collect-markdown-files.sh
+
+      - name: Run link check
+        if: steps.markdown.outputs.has_files == 'true'
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config .github/lychee.toml
+            --no-progress
+            --verbose
+            ${{ steps.markdown.outputs.files }}
+          fail: true


### PR DESCRIPTION
## Summary
This PR adds an automated markdown link validation workflow for the `GSoC` repository.

## What it adds
- `.github/workflows/markdown-link-check.yml`
  - runs on pull requests affecting markdown/docs CI files
  - checks links only in markdown files changed by the PR
- `.github/scripts/collect-markdown-files.sh`
  - computes the markdown file list from the PR diff
  - skips link checking cleanly when no markdown files are changed
- `.github/lychee.toml`
  - central lychee config (retries, timeout, accepted throttling codes)
  - excludes known legacy/flaky endpoints to reduce false negatives

## Why this is useful
We recently had broken-link regressions in documentation discussions. This workflow catches future link breakage early while avoiding unnecessary failures from untouched historical docs.

## Notes
- Scope is intentionally limited to changed markdown files for practical contributor workflow.
- No content markdown files were modified in this PR.