### PR TITLE
Add TTS limitations section to Speak-AI idea

### DIFF
--- a/Ideas-2026.md
+++ b/Ideas-2026.md
@@ -712,6 +712,11 @@ The project will require research into various TTS backends and G2P systems to d
 [Walter Bender](https://github.com/walterbender/) [Devin Ulibarri](https://github.com/pikurasa/)<br>
 
 -------------
+### Current Limitations of TTS in Sugar
+
+The current text-to-speech system has limited support for non-English and non-Latin languages. For example, languages like Hindi (Devanagari script), Arabic, and Chinese are either not supported or produce inaccurate pronunciation. This creates a barrier for many children who rely on their native languages for learning.
+
+Additionally, existing TTS systems may sound robotic and fail to capture natural speech patterns, which affects user engagement and learning experience. Improving multilingual support and pronunciation quality is essential to make the platform more inclusive and effective.
 
 # Administrative Notes
 

--- a/Ideas-2026.md
+++ b/Ideas-2026.md
@@ -1,4 +1,4 @@
-# Google Summer of Code 2026 Project Ideas
+# Google Summer of Code (GSoC) 2026 Project Ideas
 
 * [Git Backend for Music Blocks Part 2](#git-backend-for-music-blocks-part-2)
 * [GTK4 Transition Part 1 Fructose](#gtk4-transition-part-1-fructose)

--- a/Ideas-2026.md
+++ b/Ideas-2026.md
@@ -1,4 +1,4 @@
-# Google Summer of Code (GSoC) 2026 Project Ideas
+# Google Summer of Code 2026 Project Ideas
 
 * [Git Backend for Music Blocks Part 2](#git-backend-for-music-blocks-part-2)
 * [GTK4 Transition Part 1 Fructose](#gtk4-transition-part-1-fructose)


### PR DESCRIPTION
This PR adds a section highlighting current limitations of TTS systems, especially for multilingual and non-Latin languages.

This aligns with improving Speak-AI and accessibility.

I am a GSoC 2026 applicant and looking forward to contributing more.