### PR TITLE
docs: fix grammar and clarity in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 
 ## Introduction
-Google Summer of Code is a *global program focused on bringing
-more student developers into open source software development*.
+
+Google Summer of Code is a *global program focused on bringing more
+student developers into open source software development*.
 See [how it works](https://summerofcode.withgoogle.com/how-it-works).
 
 Sugar Labs is a Google Summer of Code 2026 mentoring organisation.
@@ -33,124 +34,110 @@ Our archives of GSoC Projects:
 [2024](archives/Ideas-2024.md) |
 [2025](archives/Ideas-2025.md)
 
-## Want to work with us ?
+## Want to Work with Us?
 
-Please get involved.  Familiarise yourself with our code, by
+Please get involved. Familiarise yourself with our codebase by
 reporting and fixing bugs.
 
-See our [ideas](Ideas-2026.md) page.  We would love to hear
+See our [ideas](Ideas-2026.md) page. We would love to hear
 your own ideas as well.
 
-You may use our [proposal template](Template.md) or your own.
+You may use our [proposal template](Template.md) or create your own.
 
-In addition to the [Google Summer of Code requirements for a proposal](https://google.github.io/gsocguides/student/writing-a-proposal), proposals for Sugar Labs;
+In addition to the [Google Summer of Code requirements for a proposal](https://google.github.io/gsocguides/student/writing-a-proposal), proposals for Sugar Labs must meet the following criteria:
 
-* must be your own work, and not the work of others, except where the work of others is minimal, duly credited and quoted,
-* must show you are fluent in the programming language needed,
-* must show your assessment of the competency of your mentors,
-* should be posted on our [sugar-devel@](https://lists.sugarlabs.org/mailman3/lists/sugar-devel.lists.sugarlabs.org/) mailing list as GitHub Markdown or PDF, and supported with answers to any questions posted in reply,
-* should not be posted to our [sugar-devel@](https://lists.sugarlabs.org/mailman3/lists/sugar-devel.lists.sugarlabs.org/) mailing list as a Google Docs (a document can change after you send the link, a document can disappear, the export feature may be turned off, and we don't want to require our members to use Google Docs).
+* They must be your own work, and not the work of others — except where the work of others is minimal, duly credited, and quoted.
+* They must demonstrate fluency in the programming language required for the project.
+* They must include your assessment of your mentors' competency.
+* They should be posted to our [sugar-devel@](https://lists.sugarlabs.org/mailman3/lists/sugar-devel.lists.sugarlabs.org/) mailing list as GitHub Markdown or PDF, with responses to any follow-up questions.
+* They should **not** be posted as Google Docs links — a document can be edited after submission, can disappear, may have exports disabled, and we do not want to require members to use Google Docs.
 
-For students who wish to be able to delete their proposal after failing to win a project, please do not post it on our mailing list.  Our decisions will be based on the contents of the final PDF proposal and our interactions with the student.
+If you wish to be able to delete your proposal after an unsuccessful application, please do not post it on the mailing list. Our decisions are based on the contents of the final PDF proposal and our interactions with the applicant.
 
-## How to talk to us ?
+## How to Talk to Us
+
 We use the
 [sugar-devel@](https://lists.sugarlabs.org/mailman3/lists/sugar-devel.lists.sugarlabs.org/)
-mailing list for communication. Join to participate in the discussion
-and ask for help.  Allow some days for reply.  See
+mailing list for communication. Join to participate in discussions
+and ask for help. Allow a few days for replies. See
 [Community etiquette](https://github.com/sugarlabs/GSoC#community-etiquette).
 
-We also have a [matrix channel](https://matrix.to/#/#sugar:matrix.org) where you can talk with
+We also have a [Matrix channel](https://matrix.to/#/#sugar:matrix.org) where you can talk with
 other community members.
 
-Do not write secretly to mentors or developers unless they have asked
-you to.  This varies by idea.  Check the list of coding mentors for
-each idea.  We have added contact methods.
+Do not contact mentors or developers privately unless they have explicitly
+asked you to. This varies by idea — check the list of coding mentors for
+each project for their preferred contact method.
 
 ## How to Contribute
 
 At Sugar Labs we have
 [opportunities for contributing](https://github.com/sugarlabs/sugar-docs/blob/master/src/contributing.md)
-with many different
+across many different
 [programming languages and libraries](https://github.com/sugarlabs/sugar-docs/blob/master/src/languages.md).
 
 ## Getting Help
+
 Got a problem? Ask your mentors, ask other students, or ask the
 Sugar Labs community.
 
-The Sugar Labs community is large, and there are people who are
-not mentors in the contest. Mentors are listed. Everyone else
-you talk with may be a non-mentor.
+The Sugar Labs community is large and includes many people who are
+not GSoC mentors. Mentors are listed explicitly. Keep in mind that others
+you communicate with may be non-mentors who cannot see contest progress,
+dates, or student information. When communicating broadly, be sure to:
 
-Students should keep in mind that some people are non-mentors,
-and cannot see the contest progress, dates, or information
-about students. When communicating widely, be sure to;
- - Introduce yourself, the first time,
- - Talk about the task as if you want to do it yourself, not
-   because of the contest,
- - Defend your technical decisions without using the contest as
-   a defense,
- - Non-mentors may give good guidance on technical decisions,
-   but bad guidance on how they think a task is judged. Always
-   consult with your mentors as well.
+- Introduce yourself the first time you reach out.
+- Discuss the task as something you personally want to work on — not just because of the contest.
+- Defend your technical decisions on their merits, not by citing the contest.
+- Non-mentors may offer good technical guidance but unreliable advice on how tasks are evaluated. Always consult your mentors as well.
 
-## Community etiquette
-Everyone in the community has to be polite and respectful, and
-consider everyone else a member of a team and not a competitor.
+## Community Etiquette
 
-One should be considerate to everyone else's time. We would like
-to have quality discussions, and not answer questions that are
-already documented, or available on stackoverflow. This doesn't
-mean you can't ask questions, but a clueless user and a lazy
-developer are two different things.
+Everyone in the community must be polite and respectful, treating
+each other as teammates rather than competitors.
 
-Tell things as you see them. Be polite, but don't sugar coat it.
-You don't have to apologize everytime you make a mistake; but
-avoid repeating it again ;-)
+Be considerate of everyone's time. We value quality discussions and
+prefer that you search existing documentation and resources like
+Stack Overflow before asking questions. That said, there is a clear
+difference between a new user who is learning and a developer who
+simply hasn't done the groundwork.
+
+Be honest. Be polite, but don't soften things unnecessarily.
+You don't need to apologise every time you make a mistake — just
+try not to repeat it.
 
 Also see our [Code of
 Conduct](https://github.com/sugarlabs/sugar-docs/blob/master/src/CODE_OF_CONDUCT.md).
 
-## Right fit
+## Right Fit
 
-When we start interacting with you during the application period, we have several ways to see if you are the right fit; see how you compare to our perfect student;
+During the application period, we look for the following qualities in candidates:
 
-* you have a GitHub profile with a history of commits, pull requests, and issues in our project, other projects, or personal projects,
+* You have a GitHub profile with a history of commits, pull requests, and issues — in our project, other projects, or personal projects.
+* You apply every suggestion made during pull request reviews, patiently and thoroughly.
+* You care about the project beyond your specific task — including documentation, tests, releases, and issues.
+* Your conversations with us flow naturally beyond just the task at hand.
+* You engage in substantive technical discussions and appreciate their value.
+* You don't simply do what a mentor says — you think critically and push back when appropriate.
+* You are interested in our community and follow our code of conduct and guidelines.
+* You continue contributing even if you are not selected.
+* You have contributed to our project before the application period begins.
+* You engage actively in design discussions and proposal feedback loops.
+* You do not ask others to write your proposal for you.
+* You are familiar with our software and understand what our project does.
+* You communicate in public and never contact a mentor privately unless asked.
+* You work on what the community needs, not just what personally interests you.
+* You get involved in others' work, not just your own issues.
 
-* you are patient to apply every suggestion during a pull request review,
-
-* you care about our project beyond the specific task you are working on; you care about changes to documentation, tests, releases, issues, etc,
-
-* your conversation with us is more than the topic you are working on, but flows naturally to any topic,
-
-* you are able to have a proper technical discussion; and understands the value of the discussion in itself,
-
-* you don't just say yes and do something because a mentor says so,
-
-* you are interested in our community and follow our code of conduct and guidelines,
-
-* you keep working with our community even if you are not accepted,
-
-* you have contributed to our project before the application period,
-
-* you can engage in tight feedback loops around design discussions in proposal drafts,
-
-* you don't ask for help to write a proposal,
-
-* you don't remain ignorant of our software or what our project does,
-
-* you always write in public, and never write to a mentor in private unless the mentor has asked for that,
-
-* you work on a project our community needs, regardless of your personal interests,
-
-* you don't just fix issues, but you also get involved in other people's work.
-
-<i>(abstracted by @quozl from a work-in-progress document shared among mentors of several organisations, titled "Tips for finding the right GSoC student for your org".)</i>
+*(Abstracted by @quozl from a work-in-progress document shared among mentors of several organisations, titled "Tips for finding the right GSoC student for your org".)*
 
 ## Cheating
 
-When we suspect cheating we are to report it to the GSoC coordinator.  We have a list of behaviours we look for.  We don't make that list available.
+If we suspect cheating, we will report it to the GSoC coordinator.
+We maintain a list of behaviours we watch for, which we do not publish.
 
-Your proposal, source code and other submissions must be your own work, and not the work of others.  Except where the work of others is minimal, and duly credited and quoted.  See [Cheating](https://google.github.io/gsocguides/mentor/selecting-students-and-mentors#cheating-and-proposals-from-outer-space).
+Your proposal, source code, and all other submissions must be your own
+work. The work of others must be minimal, clearly credited, and quoted.
+See [Cheating](https://google.github.io/gsocguides/mentor/selecting-students-and-mentors#cheating-and-proposals-from-outer-space).
 
 Thanks for reading all the way to the end!


### PR DESCRIPTION
1. Fixed grammar inconsistencies, heading capitalisation, and removed stray spaces before punctuation throughout the file.

2. Reworded unclear phrases for natural flow and restructured bullet points for consistent, parallel formatting.

3. Replaced the HTML <i> tag with standard Markdown italics and smoothed the Getting Help section into a proper formatted list.